### PR TITLE
Load relation catalog for each PloneSite

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,10 @@ Introduction
 
 ### INTRODUCTION ###
 
+It's important, that this package isn't started by conjob in non productive
+deployments. This is due to the fact, that the command is started by a zope
+ctl command.
+
 Compatibility
 -------------
 

--- a/ftw/linkchecker/command/checking_links.py
+++ b/ftw/linkchecker/command/checking_links.py
@@ -1,0 +1,35 @@
+from zope.component.hooks import setSite
+from Testing.makerequest import makerequest
+from AccessControl.SecurityManagement import newSecurityManager
+from zope.globalrequest import setRequest
+import AccessControl
+from zc.relation.interfaces import ICatalog
+from zope.component import getUtility
+
+
+def main(plone, *args):
+
+    # Set up request for debug / bin/instance run mode.
+    app = makerequest(plone)
+    setRequest(app.REQUEST)
+
+    houptding = app.restrictedTraverse('/')
+
+    # here all pages need to be found
+    # for now there is only 'Plone'
+    # later on we need to iterate through
+    # each page and send reports to different people
+
+    MINI_SITE = houptding.get('Plone')
+
+    user = AccessControl.SecurityManagement.SpecialUsers.system
+    user = user.__of__(MINI_SITE.acl_users)
+    newSecurityManager(MINI_SITE, user)
+
+    setSite(MINI_SITE)
+
+    relation_catalog = getUtility(ICatalog)
+
+
+if __name__ == '__main__':
+    main()

--- a/ftw/linkchecker/profiles/default/metadata.xml
+++ b/ftw/linkchecker/profiles/default/metadata.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <metadata>
     <dependencies>
+        <dependency>profile-plone.app.dexterity:default</dependency>
         <dependency>profile-ftw.upgrade:default</dependency>
     </dependencies>
 </metadata>

--- a/ftw/linkchecker/profiles/default/metadata.xml
+++ b/ftw/linkchecker/profiles/default/metadata.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
     <dependencies>
-        <dependency>profile-plone.app.dexterity:default</dependency>
         <dependency>profile-ftw.upgrade:default</dependency>
     </dependencies>
 </metadata>

--- a/ftw/linkchecker/report_mailer.py
+++ b/ftw/linkchecker/report_mailer.py
@@ -1,0 +1,49 @@
+from email import encoders
+from email.header import Header
+from email.mime.base import MIMEBase
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.utils import formatdate
+from Testing.makerequest import makerequest
+from zope.component.hooks import setSite
+import plone.api
+
+
+app = globals()['app']
+app = makerequest(app)
+
+PLONE = app.get('Plone')
+setSite(PLONE)
+
+
+def send_feedback(email_subject, email_message, receiver_email_address, report_path):
+    """Send an email including an excel workbook attached.
+    """
+    mh = plone.api.portal.get_tool('MailHost')
+    from_name = PLONE.getProperty('email_from_name', '')
+    from_email = PLONE.getProperty('email_from_address', '')
+
+    sender = 'Linkcheck Reporter'
+    recipient = from_email
+    file_name = report_path.rsplit('/', 1)[1]
+
+    msg = MIMEMultipart()
+    msg['From'] = "%s <%s>" % (from_name, from_email)
+    msg['reply-to'] = "%s <%s>" % (sender, recipient)
+    msg['To'] = receiver_email_address
+    msg['Date'] = formatdate(localtime=True)
+    msg['Subject'] = Header(email_subject, 'windows-1252')
+    msg.attach(MIMEText(email_message.encode(
+        'windows-1252'), 'plain', 'windows-1252'))
+    part = MIMEBase('application', "octet-stream")
+    part.set_payload(open(report_path, "rb").read())
+    encoders.encode_base64(part)
+    part.add_header(
+        'Content-Disposition',
+        'attachment; filename="' + file_name + '"'
+    )
+    msg.attach(part)
+
+    mh.send(msg, mto=receiver_email_address,
+            mfrom=from_email,
+            immediate=True)

--- a/setup.py
+++ b/setup.py
@@ -50,14 +50,20 @@ setup(
         'setuptools',
         'ftw.upgrade',
         'xlsxwriter',
+        'plone.api',
+        'plone.app.relationfield',
+        'plone.recipe.zope2instance',
     ],
 
     tests_require=tests_require,
     extras_require=extras_require,
 
     entry_points="""
-    # -*- Entry points: -*-
-    [z3c.autoinclude.plugin]
-    target = plone
-    """,
+      # -*- Entry points: -*-
+      [z3c.autoinclude.plugin]
+      target = plone
+
+      [zopectl.command]
+      check_links = ftw.linkchecker.command.checking_links:main
+      """,
 )


### PR DESCRIPTION
Close #6

Since we need access to the ZODB on `bin/instance check_links` an
instance is started and we can access a PloneSite of our choice.

As we found out, the command mustn't contain normal dashes.