### PR TITLE
Add script going through whole routine

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -2,6 +2,3 @@
 extends =
     test-plone-4.3.x.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
-
-[versions]
-path.py = 11.1.0

--- a/development.cfg
+++ b/development.cfg
@@ -2,3 +2,6 @@
 extends =
     test-plone-4.3.x.cfg
     https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/plone-development.cfg
+
+[versions]
+path.py = 11.1.0

--- a/ftw/linkchecker/command/checking_links.py
+++ b/ftw/linkchecker/command/checking_links.py
@@ -1,5 +1,4 @@
 from AccessControl.SecurityManagement import newSecurityManager
-from Products.CMFPlone.interfaces import IPloneSiteRoot
 from zc.relation.interfaces import ICatalog
 from zope.component import getUtility
 from zope.component.hooks import setSite
@@ -7,9 +6,19 @@ import AccessControl
 
 
 def get_plone_sites_information(app):
-    plone_sites = [obj for obj in app.objectValues(
-    ) if IPloneSiteRoot.providedBy(obj)]
-    # create information dictionary for each plone site
+
+    """Get all PloneSites and their information
+    """
+    def get_plone_sites(app):
+        for child in app.objectValues():
+            if child.meta_type == 'Plone Site':
+                yield child
+            elif child.meta_type == 'Folder':
+                for item in get_plone_sites(child):
+                    yield item
+
+    plone_sites = get_plone_sites(app)
+
     plone_sites_information = [{
         'id': plone_site.getId(),
         'path': '/'.join(plone_site.getPhysicalPath()),

--- a/ftw/linkchecker/command/checking_links.py
+++ b/ftw/linkchecker/command/checking_links.py
@@ -1,9 +1,9 @@
 from AccessControl.SecurityManagement import newSecurityManager
+from Products.CMFPlone.interfaces import IPloneSiteRoot
 from zc.relation.interfaces import ICatalog
 from zope.component import getUtility
 from zope.component.hooks import setSite
 import AccessControl
-from Products.CMFPlone.interfaces import IPloneSiteRoot
 
 
 def get_plone_sites_information(app):
@@ -34,16 +34,52 @@ def get_relation_catalog_for_plone_site(app, PloneSiteId):
 
 
 def catalog_lookup(relation_catalog):
-    x = relation_catalog
-    relations = list(x.findRelations())
+    relations = list(relation_catalog.findRelations())
     print(relations)
+
+
+def get_external_broken_links_in_plone_page(app, site_info):
+    # this function needs to find all external links in the plone site
+    # then run the script linkchecker from the branch mo/external_link_fetcher
+    return {}
+
+
+def get_broken_relations_in_plone_page(app, site_info):
+    relation_catalog = get_relation_catalog_for_plone_site(
+        app,
+        site_info['id']
+    )
+    catalog_lookup(relation_catalog)
+
+
+def create_excel_report_and_return_filepath(
+        site_info, broken_internal, broken_external):
+    # this function needs to create an excel report, safe it into a temp folder
+    # it then returns the path to that file.
+    # It makes use of the report generator from branch mo/excel_report_generator
+    pass
+
+
+def send_mail_with_excel_report_attached(email_address, path_to_report):
+    # this function sends the previously generated excel report to the
+    # responsible email address with a simple info body.
+    # It makes use of the report mailer from branch mo/mail_sending
+    pass
+
+
+def create_and_send_mailreport_to_plone_site_responible_person(
+        email_address, site_info, broken_internal, broken_external):
+    path_to_report = create_excel_report_and_return_filepath(
+        site_info, broken_internal, broken_external)
+    send_mail_with_excel_report_attached(email_address, path_to_report)
 
 
 def main(app, *args):
     plone_sites_information = get_plone_sites_information(app)
     for site_info in plone_sites_information:
-        relation_catalog = get_relation_catalog_for_plone_site(
-            app,
-            site_info['id']
-        )
-        catalog_lookup(relation_catalog)
+        email_address = 'hugo.boss@4teamwork.ch'
+        broken_internal = get_broken_relations_in_plone_page(app, site_info)
+        broken_external = get_external_broken_links_in_plone_page(
+            app, site_info)
+        create_and_send_mailreport_to_plone_site_responible_person(
+            email_address, site_info, broken_internal, broken_external)


### PR DESCRIPTION
Close #16 since it should be implemented to search in `app_root/directory` as well as expected.

One should only have to execute one command and the whole routine starts.
Therefore this script goes through every task the linkchecker has to do.