### PR TITLE
Add configuration for site administrator per plone site.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /var/
 /.nightly_password
 /README.html
+site_administrator_emails.json

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,17 @@ Installation
         ftw.linkchecker
 
 
+In the file `ftw/linkchecker/site_administrator_emails.json` one can configure
+a site administrator per plone site by plone site id.
+
+::
+
+    {
+      "plone-site-id-one": "hugo.boss@4teamwork.com",
+      "plone-site-id-one": "sec_site_admin@4teamwork.com"
+    }
+
+
 Development
 ===========
 

--- a/ftw/linkchecker/command/checking_links.py
+++ b/ftw/linkchecker/command/checking_links.py
@@ -7,6 +7,8 @@ from ftw.linkchecker.cell_format import BOLD
 from ftw.linkchecker.cell_format import CENTER
 from ftw.linkchecker.cell_format import DEFAULT_FONTNAME
 from ftw.linkchecker.cell_format import DEFAULT_FONTSIZE
+from os.path import abspath
+from os.path import dirname
 from plone import api
 from plone.app.textfield.interfaces import IRichText
 from plone.dexterity.interfaces import IDexterityFTI
@@ -18,6 +20,7 @@ from zope.component.hooks import setSite
 from zope.schema import getFieldsInOrder
 from zope.schema.interfaces import IURI
 import AccessControl
+import json
 import os
 import re
 import time
@@ -373,15 +376,20 @@ def send_mail_with_excel_report_attached(email_address, path_to_report,
 
 def main(app, *args):
     plone_site_objs = get_plone_sites_information(app)
+
+    path_site_administrator_emails = os.path.join(
+        dirname(dirname(abspath(__file__))), 'site_administrator_emails.json')
+    with open(path_site_administrator_emails) as f_:
+        site_administrator_emails = json.load(f_)
+
     for plone_site_obj in plone_site_objs:
-        email_address = 'hugo.boss@4teamwork.ch'
+        plone_site_id = plone_site_obj.getId()
+        email_address = site_administrator_emails[plone_site_id]
 
         setup_plone(app, plone_site_obj)
-
         broken_relations_and_links_info = get_broken_relations_and_links()
         broken_relations_and_links = broken_relations_and_links_info[1]
         total_time_fetching_external = broken_relations_and_links_info[0]
-
         create_and_send_mailreport_to_plone_site_responible_person(
             email_address, broken_relations_and_links, plone_site_obj,
             total_time_fetching_external)

--- a/ftw/linkchecker/command/checking_links.py
+++ b/ftw/linkchecker/command/checking_links.py
@@ -197,12 +197,33 @@ def add_link_info_to_links(content, link_and_relation_information, obj):
     return link_and_relation_information
 
 
+def extract_relation_uids_in_string(input_string):
+    regex = "resolveuid/\w{32}"
+    uids_long_form = re.findall(regex, input_string)
+    uids = []
+    for uid in uids_long_form:
+        uids.extend(uid.split('/')[1])
+    return uids
+
+def get_broken_relation_information_by_uids(relation_uids, obj):
+    information_of_broken_relations = []
+    for relation_uid in relation_uids:
+        if api.content.get(UID=relation_uid):
+            information_of_broken_relations.append({
+                'origin': obj.absolute_url_path(),
+                'destination': 'Ds weis dr Gugger'
+            })
+    return information_of_broken_relations
 
 def add_link_info_to_links(content, link_information_collection, obj):
 
     if not isinstance(content, basestring):
         return
     links = extract_links_in_string(content)
+    relation_uids = extract_relation_uids_in_string(content)
+    get_broken_relation_information_by_uids(relation_uids, obj)
+    import pdb; pdb.set_trace()
+
     if not links:
         # only continue if there are any links
         return

--- a/ftw/linkchecker/command/checking_links.py
+++ b/ftw/linkchecker/command/checking_links.py
@@ -197,6 +197,23 @@ def add_link_info_to_links(content, link_and_relation_information, obj):
     return link_and_relation_information
 
 
+
+def add_link_info_to_links(content, link_information_collection, obj):
+
+    if not isinstance(content, basestring):
+        return
+    links = extract_links_in_string(content)
+    if not links:
+        # only continue if there are any links
+        return
+
+    for link in links:
+        link_information_collection.append({
+            'origin': obj.absolute_url_path(),
+            'destination': link,
+        })
+
+
 def find_links_on_brain_fields(brain):
     obj = brain.getObject()
     link_and_relation_information = []

--- a/ftw/linkchecker/command/checking_links.py
+++ b/ftw/linkchecker/command/checking_links.py
@@ -202,37 +202,49 @@ def extract_relation_uids_in_string(input_string):
     uids_long_form = re.findall(regex, input_string)
     uids = []
     for uid in uids_long_form:
-        uids.extend(uid.split('/')[1])
+        uids.append(uid.split('/')[1])
     return uids
+
 
 def get_broken_relation_information_by_uids(relation_uids, obj):
     information_of_broken_relations = []
     for relation_uid in relation_uids:
-        if api.content.get(UID=relation_uid):
-            information_of_broken_relations.append({
-                'origin': obj.absolute_url_path(),
-                'destination': 'Ds weis dr Gugger'
-            })
+        if not api.content.get(UID=relation_uid):
+            information_of_broken_relations.append([
+                'internal',
+                obj.absolute_url_path(),
+                'Unknown location',
+                'Not specified',
+                'Not specified',
+                'Not specified',
+                'Not specified',
+                'Not specified',
+            ])
     return information_of_broken_relations
 
-def add_link_info_to_links(content, link_information_collection, obj):
 
+def add_link_info_to_links(content, link_and_relation_information, obj):
     if not isinstance(content, basestring):
         return
+    # find links in page
     links = extract_links_in_string(content)
+    # find and add broken relations to link_and_relation_information
     relation_uids = extract_relation_uids_in_string(content)
-    get_broken_relation_information_by_uids(relation_uids, obj)
-    import pdb; pdb.set_trace()
+    broken_relations = get_broken_relation_information_by_uids(relation_uids,
+                                                               obj)
+    link_and_relation_information.extend(broken_relations)
 
     if not links:
         # only continue if there are any links
         return
 
     for link in links:
-        link_information_collection.append({
-            'origin': obj.absolute_url_path(),
-            'destination': link,
-        })
+        link_and_relation_information.append([
+            'external',
+            obj.absolute_url_path(),
+            link,
+        ])
+    return link_and_relation_information
 
 
 def find_links_on_brain_fields(brain):

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,12 @@ tests_require = [
     'plone.testing',
     'pandas==0.22.0',
     'xlrd >= 0.9.0',
+<<<<<<< HEAD
     'requests',
     'xlsxwriter',
+=======
+    'requests'
+>>>>>>> Fix: Changes were reviewed earlier and merged at some point already
 ]
 
 extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
-from setuptools import setup, find_packages
 import os
+
+from setuptools import find_packages
+from setuptools import setup
 
 version = '1.0.0.dev0'
 
@@ -11,12 +13,8 @@ tests_require = [
     'plone.testing',
     'pandas==0.22.0',
     'xlrd >= 0.9.0',
-<<<<<<< HEAD
     'requests',
     'xlsxwriter',
-=======
-    'requests'
->>>>>>> Fix: Changes were reviewed earlier and merged at some point already
 ]
 
 extras_require = {


### PR DESCRIPTION
Closing #15 

To be able to send reports per plone site installation (to separate
site administrators) we need to have a configuration file for these
settings.