### PR TITLE
Change config file loading

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,8 @@ ids and their site administrators email addresses like:
       "plone-site-id-one": "sec_site_admin@4teamwork.com"
     }
 
+Json files do not have a comma at the end of the last entry!
+
 
 Usage
 =====

--- a/README.rst
+++ b/README.rst
@@ -31,8 +31,8 @@ Installation
         ftw.linkchecker
 
 
-In the file `ftw/linkchecker/site_administrator_emails.json` one can configure
-a site administrator per plone site by plone site id.
+One needs to add a config file (e.g. linkchecker_config.json) holding the sites
+ids and their site administrators email addresses like:
 
 ::
 
@@ -40,6 +40,16 @@ a site administrator per plone site by plone site id.
       "plone-site-id-one": "hugo.boss@4teamwork.com",
       "plone-site-id-one": "sec_site_admin@4teamwork.com"
     }
+
+
+Usage
+=====
+
+The linkchecker can be started with:
+
+::
+
+    bin/instance check_links --config path/to/config/file.json
 
 
 Development

--- a/ftw/linkchecker/command/checking_links.py
+++ b/ftw/linkchecker/command/checking_links.py
@@ -8,8 +8,6 @@ from ftw.linkchecker.cell_format import BOLD
 from ftw.linkchecker.cell_format import CENTER
 from ftw.linkchecker.cell_format import DEFAULT_FONTNAME
 from ftw.linkchecker.cell_format import DEFAULT_FONTSIZE
-from os.path import abspath
-from os.path import dirname
 from plone import api
 from plone.app.textfield.interfaces import IRichText
 from plone.dexterity.interfaces import IDexterityFTI
@@ -23,6 +21,7 @@ from zope.globalrequest import setRequest
 from zope.schema import getFieldsInOrder
 from zope.schema.interfaces import IURI
 import AccessControl
+import argparse
 import json
 import os
 import re
@@ -355,13 +354,26 @@ def send_mail_with_excel_report_attached(email_address, path_to_report,
         email_subject, email_message, email_address, path_to_report)
 
 
+def get_config_file(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config",
+                        help="Path to linkchecker config file.")
+    args, unknown = parser.parse_known_args()
+    path_to_config_file = args.config
+
+    if not os.path.isfile(path_to_config_file):
+        exit()
+
+    with open(path_to_config_file) as f_:
+        site_administrator_emails = json.load(f_)
+
+    return site_administrator_emails
+
+
 def main(app, *args):
     plone_site_objs = get_plone_sites_information(app)
 
-    path_site_administrator_emails = os.path.join(
-        dirname(dirname(abspath(__file__))), 'site_administrator_emails.json')
-    with open(path_site_administrator_emails) as f_:
-        site_administrator_emails = json.load(f_)
+    site_administrator_emails = get_config_file(args)
 
     for plone_site_obj in plone_site_objs:
         plone_site_id = plone_site_obj.getId()


### PR DESCRIPTION
So that the config file is not in the egg I added an argument parser reading the path to the file holding the information to site administrators emails.