### PR TITLE
Fix: Find PloneSites not only on root but recursively.

### DIFF
--- a/ftw/linkchecker/command/checking_links.py
+++ b/ftw/linkchecker/command/checking_links.py
@@ -29,11 +29,13 @@ import os
 import re
 
 
-def get_plone_sites_information(app):
-    plone_site_objs = [obj for obj in app.objectValues(
-    ) if IPloneSiteRoot.providedBy(obj)]
-
-    return plone_site_objs
+def get_plone_sites(obj):
+    for child in obj.objectValues():
+        if child.meta_type == 'Plone Site':
+            yield child
+        elif child.meta_type == 'Folder':
+            for item in get_plone_sites(child):
+                yield item
 
 
 def setup_plone(app, plone_site_obj):
@@ -266,7 +268,7 @@ def send_mail_with_excel_report_attached(email_address, plone_site_obj,
 
 
 def main(app, *args):
-    plone_site_objs = get_plone_sites_information(app)
+    plone_site_objs = list(get_plone_sites(app))
 
     path_site_administrator_emails = os.path.join(
         dirname(dirname(abspath(__file__))), 'site_administrator_emails.json')


### PR DESCRIPTION
🚧 Needs #33 to be merged. Rebase and change base to master before merging. 🚧 

Plone Sites couldn't be found in a real life installation (having ftw.linkchecker installed as a package). Hence I needed to fix this using a recursive loop searching for Plone Sites.