### PR TITLE
Fix: Resolve all archetype objects and unicode error

### DIFF
--- a/ftw/linkchecker/command/broken_link.py
+++ b/ftw/linkchecker/command/broken_link.py
@@ -1,5 +1,6 @@
 from plone import api
 from plone.dexterity.utils import safe_utf8
+from plone.api.portal import get_tool
 
 
 class BrokenLink(object):
@@ -46,7 +47,8 @@ class BrokenLink(object):
         self.link_target = url
 
     def complete_information_with_internal_uid(self, obj_having_uid, uid):
-        if not api.content.get(UID=uid):
+        portal_catalog = get_tool('portal_catalog')
+        if not list(portal_catalog.unrestrictedSearchResults(UID=uid)):
             self.is_broken = True
             self.is_internal = True
             self.link_origin = '/'.join(obj_having_uid.getPhysicalPath())

--- a/ftw/linkchecker/command/broken_link.py
+++ b/ftw/linkchecker/command/broken_link.py
@@ -1,6 +1,9 @@
 from plone import api
-from plone.dexterity.utils import safe_utf8
 from plone.api.portal import get_tool
+from plone.app.redirector.interfaces import IRedirectionStorage
+from plone.dexterity.utils import safe_utf8
+from urlparse import urlparse
+from zope.component import getUtility
 
 
 class BrokenLink(object):
@@ -32,7 +35,11 @@ class BrokenLink(object):
     def complete_information_with_internal_path(self, obj_having_path, path):
         # relation not broken if possible to traverse to
         try:
-            api.portal.get().unrestrictedTraverse(safe_utf8(path))
+            path = urlparse(
+                safe_utf8(path).rstrip('/view').rstrip('/download')).path
+            storage = getUtility(IRedirectionStorage)
+            path = storage.get(path, path)
+            api.portal.get().unrestrictedTraverse(path)
             self.is_broken = False
             self.is_internal = True
         except Exception:

--- a/ftw/linkchecker/command/checking_links.py
+++ b/ftw/linkchecker/command/checking_links.py
@@ -140,7 +140,8 @@ def find_links_on_brain_fields(brain):
             # if there is a string having a valid scheme it will be embedded
             # into a href, so we can use the same method as for the dexterity
             # strings and do not need to change the main use case.
-            if urlparse(content).scheme:
+            scheme = urlparse(content).scheme
+            if scheme and scheme in ['http', 'https']:
                 content = 'href="%s"' % content
             extract_and_append_link_objs(content, obj, link_objs)
 

--- a/ftw/linkchecker/report_generating.py
+++ b/ftw/linkchecker/report_generating.py
@@ -42,10 +42,10 @@ class ReportCreator(object):
             # remove portal path in link_target and link_origin
             portal_path_segments = api.portal.get().getPhysicalPath()
             portal_reg = re.compile('^' + '/'.join(portal_path_segments))
-            link_obj.link_origin = re.sub(portal_reg, base_uri,
-                                          link_obj.link_origin)
-            link_obj.link_target = re.sub(portal_reg, base_uri,
-                                          link_obj.link_target)
+            link_obj.link_origin = re.sub(portal_reg, safe_unicode(base_uri),
+                                          safe_unicode(link_obj.link_origin))
+            link_obj.link_target = re.sub(portal_reg, safe_unicode(base_uri),
+                                          safe_unicode(link_obj.link_target))
 
             self.worksheet.write(self.row, 0, int_ext_link, format)
             self.worksheet.write(self.row, 1,


### PR DESCRIPTION
Using "api.content.get(UID=uid)" was not able to find archetype objects
in many cases. Using the portal_catalog solves this problem.

There is need for having safe_unicode at additional places.