### PR TITLE
Only check probable fields and limit link length

### DIFF
--- a/ftw/linkchecker/command/checking_links.py
+++ b/ftw/linkchecker/command/checking_links.py
@@ -1,6 +1,8 @@
 from AccessControl.SecurityManagement import newSecurityManager
+from Products.Archetypes.Field import ComputedField
 from Products.Archetypes.Field import ReferenceField
-from Products.CMFPlone.interfaces import IPloneSiteRoot
+from Products.Archetypes.Field import StringField
+from Products.Archetypes.Field import TextField
 from Testing.makerequest import makerequest
 from ftw.linkchecker import linkchecker
 from ftw.linkchecker import report_generating
@@ -124,6 +126,8 @@ def find_links_on_brain_fields(brain):
     if not queryUtility(IDexterityFTI, name=obj.portal_type):
         # is not dexterity
         for field in obj.Schema().fields():
+            if not isinstance(field, (TextField, ReferenceField, ComputedField, StringField)):
+                continue
             content = field.getRaw(obj)
             if isinstance(field, ReferenceField):
                 uid = content

--- a/ftw/linkchecker/report_generating.py
+++ b/ftw/linkchecker/report_generating.py
@@ -49,9 +49,11 @@ class ReportCreator(object):
 
             self.worksheet.write(self.row, 0, int_ext_link, format)
             self.worksheet.write(self.row, 1,
-                                 safe_unicode(link_obj.link_origin), format)
+                                 safe_unicode(link_obj.link_origin)[:254],
+                                 format)
             self.worksheet.write(self.row, 2,
-                                 safe_unicode(link_obj.link_target), format)
+                                 safe_unicode(link_obj.link_target)[:254],
+                                 format)
             self.worksheet.write(self.row, 3,
                                  safe_unicode(link_obj.status_code), format)
             self.worksheet.write(self.row, 4,


### PR DESCRIPTION
Close #50 
Close #46

__Only check probable fields__
Instead of checking all archetype fields we can only check the fields
which are likely to contain any links/relations.

__Limit link to 254 chars__
The excel sheet was broken if links were exceeding more than 254 chars.
Therefore this change limits links written to the sheet to less chars
than that.