### PR TITLE
Pin down collective.z3cform.datagridfield

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -10,3 +10,5 @@ versions = versions
 
 
 [versions]
+# Plone 4 support got dropped in 1.4.0
+collective.z3cform.datagridfield = <1.4.0


### PR DESCRIPTION
Plone 4 support got dropped in 1.4.0.