### PR TITLE
Remove ignoring ssl certificates

### DIFF
--- a/ftw/linkchecker/linkchecker.py
+++ b/ftw/linkchecker/linkchecker.py
@@ -20,8 +20,7 @@ def get_uri_response(external_link_obj, timeout):
         response = requests.head(external_link_obj.link_target,
                                  timeout=timeout,
                                  headers=headers,
-                                 allow_redirects=False,
-                                 verify=False)
+                                 allow_redirects=False)
     except requests.exceptions.Timeout:
         error = 'Timeout'
     except requests.exceptions.TooManyRedirects:


### PR DESCRIPTION
🚧 We need to test that in a real db first 🚧 

Close https://github.com/4teamwork/ftw.linkchecker/issues/57

This pull removes the ignoring ssl cert line.
We should not ignore if pages are uncertified and better add these to the report.