### PR TITLE
Fix version conflicts

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix version conflict in test packages. [busykoala]
 
 
 1.0.0 (2019-08-02)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,10 @@ tests_require = [
     'ftw.testing',
     'plone.app.testing',
     'plone.testing',
-    'pandas==0.22.0',
+    # later versions of pandas require python-dateutil>=2.5.0
+    'pandas < 0.23.0',
+    # from numpy 1.17.0 only python >= 3.5 is supported
+    'numpy < 1.17.0',
     'xlrd >= 0.9.0',
     'requests',
     'xlsxwriter',


### PR DESCRIPTION
Pandas later than 0.22.x requires python-dateutils>=2.5.0 which conflicts.
Numpy greater than 1.16.x dropped python 2.7 support.