### PR TITLE
Remove duplicate "Introduction" header in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,6 @@ ftw.linkchecker
 Introduction
 ============
 
-### INTRODUCTION ###
-
 It's important, that this package isn't started by conjob in non productive
 deployments. This is due to the fact, that the command is started by a zope
 ctl command.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove duplicate "Introduction" header in readme [Nachtalb]
 
 
 1.1.1 (2019-08-13)


### PR DESCRIPTION
Saw it and thought why not fix it directly 🤷‍♂ 
Don't have to do a release or anything. Can come with the next one you'll make.