### PR TITLE
Log and request using utf-8.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Log and make requests with link utf-8 encoded. [busykoala]
 
 
 1.3.0 (2019-09-10)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - Log and make requests with link utf-8 encoded. [busykoala]
+- Extend LinkObject table attributes so autofilter covers all columns. [busykoala]
 
 
 1.3.0 (2019-09-10)

--- a/ftw/linkchecker/command/broken_link.py
+++ b/ftw/linkchecker/command/broken_link.py
@@ -15,7 +15,8 @@ class BrokenLink(object):
         'content_type',
         'response_time',
         'error_message',
-        'creator'
+        'creator',
+        'source_state'
     ]
 
     def __init__(self):

--- a/ftw/linkchecker/linkchecker.py
+++ b/ftw/linkchecker/linkchecker.py
@@ -13,7 +13,8 @@ def millis():
 
 def get_uri_response(external_link_obj, timeout):
     logger = logging.getLogger(LOGGER_NAME)
-    logger.info('Head request to {}'.format(external_link_obj.link_target))
+    logger.info('Head request to {}'.format(
+        external_link_obj.link_target.encode('utf-8')))
 
     headers = {
         'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'
@@ -22,7 +23,7 @@ def get_uri_response(external_link_obj, timeout):
     response = None
     start_time = millis()
     try:
-        response = requests.head(external_link_obj.link_target,
+        response = requests.head(external_link_obj.link_target.encode('utf-8'),
                                  timeout=timeout,
                                  headers=headers,
                                  allow_redirects=False,


### PR DESCRIPTION
Not all symbols used in links were in ASCII range. System out was encoding in the standard way (ASCII) and therefore threw an UnicodeEncodeError. Also when links contain umlauts they were not encoded correctly (this actually was the case 🤤).