### PR TITLE
Replace encode utf-8 with safe_utf8.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add logger to mailer and ensure utf-8 when logging. [busykoala]
 
 
 1.3.1 (2019-09-11)

--- a/ftw/linkchecker/linkchecker.py
+++ b/ftw/linkchecker/linkchecker.py
@@ -2,6 +2,7 @@ from ftw.linkchecker import LOGGER_NAME
 from ftw.linkchecker.pool_with_logging import PoolWithLogging
 from functools import partial
 from multiprocessing import cpu_count
+from plone.dexterity.utils import safe_utf8
 import logging
 import requests
 import time
@@ -13,8 +14,7 @@ def millis():
 
 def get_uri_response(external_link_obj, timeout):
     logger = logging.getLogger(LOGGER_NAME)
-    logger.info('Head request to {}'.format(
-        external_link_obj.link_target.encode('utf-8')))
+    logger.info(safe_utf8(u'Head request to {}'.format(external_link_obj.link_target)))
 
     headers = {
         'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'

--- a/ftw/linkchecker/report_mailer.py
+++ b/ftw/linkchecker/report_mailer.py
@@ -5,7 +5,10 @@ from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import formatdate
+from ftw.linkchecker import LOGGER_NAME
+from plone.dexterity.utils import safe_utf8
 from zope.component.hooks import setSite
+import logging
 import plone.api
 import time
 
@@ -51,3 +54,6 @@ class MailSender(object):
         mh.send(msg, mto=receiver_email_address,
                 mfrom=from_email,
                 immediate=True)
+        logger = logging.getLogger(LOGGER_NAME)
+        logger.info(safe_utf8(
+            u'Sent email to {}'.format(receiver_email_address)))


### PR DESCRIPTION
This replaces encode('utf-8') with ensure_utf8 and also adds a logger into the mailer.