### PR TITLE
Fail if unknown args are given.

### DIFF
--- a/ftw/linkchecker/configuration.py
+++ b/ftw/linkchecker/configuration.py
@@ -22,7 +22,7 @@ class Configuration(object):
                             help="Path to linkchecker config file.")
         parser.add_argument("--log",
                             help="Path to linkchecker log file.")
-        args, unknown = parser.parse_known_args()
+        args, unknown = parser.parse_args()
 
         self.config_file_path = safe_utf8(args.config)
         self.log_file_path = safe_utf8(args.log)

--- a/ftw/linkchecker/configuration.py
+++ b/ftw/linkchecker/configuration.py
@@ -22,7 +22,7 @@ class Configuration(object):
                             help="Path to linkchecker config file.")
         parser.add_argument("--log",
                             help="Path to linkchecker log file.")
-        args, unknown = parser.parse_args()
+        args = parser.parse_args()
 
         self.config_file_path = safe_utf8(args.config)
         self.log_file_path = safe_utf8(args.log)


### PR DESCRIPTION
Close https://github.com/4teamwork/ftw.linkchecker/issues/83

By using parse_args instead of parse_known_args we can let the program fail if unexpected args are given.