### PR TITLE
Change note regarding sl FilelistingBlock.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,8 @@ The following options can be configured in the config file per platform:
 - base URI (domain where the platform is configured - it will be prepended to the report)
 - timeout in seconds (how long the script waits for each external link before
   continuing if the page does not respond).
-- upload_location can be left empty. It is the path to a ``ftw.simplelayout`` file listing
+- upload_location can be left empty.
+  It could be a path to e.g. a ``ftw.simplelayout`` file listing
   block where the report will additionally be uploaded.
 
 

--- a/README.rst
+++ b/README.rst
@@ -59,8 +59,8 @@ The following options can be configured in the config file per platform:
 - timeout in seconds (how long the script waits for each external link before
   continuing if the page does not respond).
 - upload_location can be left empty.
-  It could be a path to e.g. a ``ftw.simplelayout`` file listing
-  block where the report will additionally be uploaded.
+  If set, it should be a path to a Plone container type (such as a Folder or a ``ftw.simplelayout`` file listing
+  block) where the report `File` will additionally be uploaded.
 
 
 ::


### PR DESCRIPTION
Close https://github.com/4teamwork/ftw.linkchecker/issues/82

The upload path does not necessarily have to be a ftw.simplelayout FilelistingBlock. Thus I changed the note suggesting this type as an example instead of making it a condition.