### PR TITLE
Make number of processes spawned configurable.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,12 +90,14 @@ Run command for ftw.linkchecker.
 
 ::
 
-    bin/instance check_links /path/to/settings.json [-l /path/to/logfile.log]
+    bin/instance check_links /path/to/settings.json [-l /path/to/logfile.log] [-p processes]
 
 
 - The first (positional) argument is the path to the settings file.
 - The second (optional) argument (prefixed with ``-l`` or ``--logpath``) is
   the path to a logfile (which was created in advance).
+- The third (optional) argument (prefixed with ``-p`` or ``--processes``) is
+  the maximal number of processes spawned for the head requests.
 
 
 Development

--- a/ftw/linkchecker/configuration.py
+++ b/ftw/linkchecker/configuration.py
@@ -10,6 +10,7 @@ class Configuration(object):
     def __init__(self, args):
         self.config_file_path = ''
         self.log_file_path = ''
+        self.max_processes = None
         self.sites = []
 
         self._parse_arguments(args)
@@ -18,16 +19,19 @@ class Configuration(object):
 
     def _parse_arguments(self, args):
         parser = argparse.ArgumentParser(
-            usage='bin/instance check_links settings [-l logpath]')
+            usage='bin/instance check_links settings [-l logpath] [-p processes]')
         parser.add_argument('-c', '--command', help=argparse.SUPPRESS)
         parser.add_argument('settings',
                             help='Path of the linkchecker settings file.')
         parser.add_argument('-l', '--logpath',
                             help='Path of the linkchecker log file.')
+        parser.add_argument('-p', '--processes', type=int,
+                            help='Max. number of processes spawned.')
         args = parser.parse_args()
 
         self.config_file_path = safe_utf8(args.settings)
         self.log_file_path = safe_utf8(args.logpath)
+        self.max_processes = int(args.processes)
 
     def _validate_args(self):
         if not self.config_file_path or not os.path.exists(

--- a/ftw/linkchecker/link_accumulation.py
+++ b/ftw/linkchecker/link_accumulation.py
@@ -43,7 +43,12 @@ class Accumulator(object):
 
         status_checker = StatusChecker(
             self._external_link_objs, self._site_config.configuration.timeout_config)
-        status_checker.work_through_urls()
+
+        if self._site_config.max_processes:
+            status_checker.work_through_urls(
+                processes=self._site_config.max_processes)
+        else:
+            status_checker.work_through_urls()
 
         self.external_broken_link_objs = status_checker.broken_external_links
         self.time_external_routine = status_checker.total_time

--- a/ftw/linkchecker/per_site_configuration.py
+++ b/ftw/linkchecker/per_site_configuration.py
@@ -13,6 +13,7 @@ class PerSiteConfiguration():
 
     def __init__(self, plone_site, configuration):
         self.configuration = configuration
+        self.max_processes = configuration.max_processes
         self.upload_path = ''
         self.logger = logging.getLogger(LOGGER_NAME)
 

--- a/ftw/linkchecker/status_checker.py
+++ b/ftw/linkchecker/status_checker.py
@@ -17,10 +17,10 @@ class StatusChecker(object):
         self._external_link_objs = external_link_objs
         self._timeout_config = timeout_config
 
-    def work_through_urls(self):
+    def work_through_urls(self, processes=cpu_count()):
         # prepare worker function and pool
         part_get_uri_response = partial(_get_uri_response, timeout=self._timeout_config)
-        pool = PoolWithLogging(processes=cpu_count(), logger_name=LOGGER_NAME)
+        pool = PoolWithLogging(processes=processes, logger_name=LOGGER_NAME)
 
         start_time = _millis()
         self._external_link_objs = pool.map(


### PR DESCRIPTION
Close #95 

❗️ Rebase onto master (and change base) before merging!

Especially for testruns it is very handy if the number of processes spawned are configurable.
But also if a server can handle it can be nice to accelerate fetching for links.
Since the bottleneck doing request usually is the response time it totally makes sence that
a higher number of processes can be configured.