### PR TITLE
Setup annotations and registry.

### DIFF
--- a/ftw/linkchecker/browser/dashboard.py
+++ b/ftw/linkchecker/browser/dashboard.py
@@ -1,5 +1,34 @@
+from plone import api
+from zope.annotation.interfaces import IAnnotations
 from zope.publisher.browser import BrowserView
 
 
 class Dashboard(BrowserView):
+
+    def __init__(self, context, request):
+        super(Dashboard, self).__init__(context, request)
+        self.dashboard_model = DashboardModel(self.context, self.request)
+        self.graph_generator = GraphGenerator()
+
+
+class DashboardModel(object):
+
+    def __init__(self, context, request):
+        self.request = request
+        self.context = context
+
+    def _get_report_path(self):
+        return api.portal.get_registry_record(
+            'ftw.linkchecker.dashboard_storage')
+
+    def _set_annotation(self, data):
+        annotations = IAnnotations(self.context)
+        annotations['ftw.linkchecker.link_data'] = data
+
+    def _get_annotation(self):
+        annotations = IAnnotations(self.context)
+        return annotations['ftw.linkchecker.link_data']
+
+
+class GraphGenerator(object):
     pass

--- a/ftw/linkchecker/profiles/default/registry.xml
+++ b/ftw/linkchecker/profiles/default/registry.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<registry>
+    <record name="ftw.linkchecker.dashboard_storage">
+        <field type="plone.registry.field.TextLine">
+            <title>Storage of the linkchecker dashboard.</title>
+            <required>False</required>
+        </field>
+        <value>linkchecker/reports</value>
+    </record>
+</registry>

--- a/ftw/linkchecker/profiles/uninstall/registry.xml
+++ b/ftw/linkchecker/profiles/uninstall/registry.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<registry>
+    <record name="ftw.linkchecker.dashboard_storage" remove="True" />
+</registry>

--- a/ftw/linkchecker/tests/test_dashboard_model.py
+++ b/ftw/linkchecker/tests/test_dashboard_model.py
@@ -1,0 +1,30 @@
+from ftw.linkchecker.browser.dashboard import Dashboard
+from ftw.linkchecker.tests import FunctionalTestCase
+
+
+class TestDashboardFunctional(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestDashboardFunctional, self).setUp()
+        self.grant(self.portal, 'Manager')
+
+    def test_read_path_from_registry(self):
+
+        dashboard = Dashboard(self.portal, self.request)
+
+        self.assertEqual(
+            u'linkchecker/reports', dashboard.dashboard_model._get_report_path(),
+            'It is expected to get the path configured in the registry.')
+
+    def test_write_and_read_annotation(self):
+
+        dashboard = Dashboard(self.portal, self.request)
+        expected = {'data': 'example data'}
+
+        # set annotation to expected
+        dashboard.dashboard_model._set_annotation(expected)
+
+        self.assertEqual(
+            expected, dashboard.dashboard_model._get_annotation(),
+            'It is expected that the annotation value can be set and get.')
+

--- a/ftw/linkchecker/tests/test_graph_generator.py
+++ b/ftw/linkchecker/tests/test_graph_generator.py
@@ -1,0 +1,17 @@
+from ftw.linkchecker.browser.dashboard import Dashboard
+from ftw.linkchecker.browser.dashboard import GraphGenerator
+from ftw.linkchecker.tests import FunctionalTestCase
+
+
+class TestDashboardFunctional(FunctionalTestCase):
+
+    def setUp(self):
+        super(TestDashboardFunctional, self).setUp()
+        self.grant(self.portal, 'Manager')
+
+    def test_init_graph_creator(self):
+        dashboard = Dashboard(self.portal, self.request)
+
+        self.assertTrue(
+            isinstance(dashboard.graph_generator, GraphGenerator),
+            'It is expected that the dashboard graph_generator is of class GraphGenerator.')


### PR DESCRIPTION
To be able to persist the state of broken relations annotations are used.
Also it is necessary to retrieve the path of the report file at runtime for which the registry will be used.

The path to the report file intentionally is not unified with the json settings file so that the linkchecker can be used with and without installing the profile.