### PR TITLE
Inherit from user-panel view and copy parts of its template.

### DIFF
--- a/ftw/linkchecker/browser/configure.zcml
+++ b/ftw/linkchecker/browser/configure.zcml
@@ -4,6 +4,11 @@
     xmlns:browser="http://namespaces.zope.org/browser"
     i18n_domain="ftw.linkchecker">
 
+    <browser:resourceDirectory
+      name="ftw.linkchecker-resources"
+      directory="resources"
+      />
+
     <browser:page
         for="Products.CMFPlone.interfaces.siteroot.IPloneSiteRoot"
         name="linkchecker-dashboard"

--- a/ftw/linkchecker/browser/dashboard.pt
+++ b/ftw/linkchecker/browser/dashboard.pt
@@ -32,6 +32,8 @@
               class="line-chart history-plot" />
 
         <div id="content-core">
+
+          <div tal:repeat="link_item python:enumerate(view.get_links())">
           <form action=""
                 class="enableAutoFocus"
                 name="users_search"
@@ -84,13 +86,15 @@
                                          title userid">
                         <tal:block replace="structure context/portal_url/user.png"/>&nbsp;<span tal:replace="user/fullname">Full Name</span>
                       </a>
-                      <input type="hidden" name="users.id:records" tal:attributes="value userid" />
+
+                      <tal:definition tal:define="link_number python:link_item[0];
+                                                  link_data python:link_item[1]">
                       <input class="context"
                              type="submit"
-                             name="form.button.AssignUser"
-                             value="users.id:records"
-                             i18n:attributes="value label_apply_changes;"
+                             tal:attributes="value string:Assign;
+                                             name string:assign_${link_number}_${userid}"
                        />
+                      </tal:definition>
 
                     </td>
                   </tr>
@@ -134,6 +138,8 @@
             <input tal:replace="structure context/@@authenticator/authenticator" />
 
           </form>
+          </div>
+
         </div>
       </div>
     </div>

--- a/ftw/linkchecker/browser/dashboard.pt
+++ b/ftw/linkchecker/browser/dashboard.pt
@@ -1,33 +1,143 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
-      xmlns:metal="http://xml.zope.org/namespaces/metal"
-      metal:use-macro="here/main_template/macros/master"
       xmlns:tal="http://xml.zope.org/namespaces/tal"
-      i18n:domain="ftw.linkchecker"
-      lang="en">
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="context/prefs_main_template/macros/master"
+      i18n:domain="ftw.linkchecker">
 
-  <body>
+<body>
+  <metal:main fill-slot="prefs_configlet_content"
+      tal:define="template_id string:@@linkchecker-dashboard;
+                  showAll python:request.get('showAll', '') and not view.newSearch and 'y';
+                  Batch python:modules['Products.CMFPlone'].Batch;
+                  b_start python:0 if showAll or view.newSearch else request.get('b_start',0);
+                  b_size python:showAll and len(view.searchResults) or 20;
+                  portal_roles view/portal_roles;
+                  portal_url context/portal_url;">
 
-    <metal:main fill-slot="content-title">
-      <h1 class="documentFirstHeading" i18n:translate="">Linkchecker Dashboard</h1>
-    </metal:main>
+    <div class="documentEditable">
+      <div id="content">
 
-    <div metal:fill-slot="content-core">
-      <span tal:content="structure view/graph_generator/get_status_plot"
-            class="pie-chart status-plot" />
-      <span tal:content="structure view/graph_generator/get_creator_plot"
-            class="pie-chart creator-plot" />
-      <span tal:content="structure view/graph_generator/get_workflow_plot"
-            class="pie-chart workflow-plot" />
-      <span tal:content="structure view/graph_generator/get_history_plot"
-            class="line-chart history-plot" />
-      <p>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-      Illa videamus, quae a te de amicitia dicta sunt.
-      Rationis enim perfectio est virtus;
-      Quis contra in illa aetate pudorem, constantiam,
-      etiamsi sua nihil intersit, non tamen diligat?
-      </p>
+        <h1 class="documentFirstHeading"
+            i18n:translate="">Linkchecker Dashboard</h1>
+
+        <span tal:content="structure view/graph_generator/get_status_plot"
+              class="pie-chart status-plot" />
+        <span tal:content="structure view/graph_generator/get_creator_plot"
+              class="pie-chart creator-plot" />
+        <span tal:content="structure view/graph_generator/get_workflow_plot"
+              class="pie-chart workflow-plot" />
+        <span tal:content="structure view/graph_generator/get_history_plot"
+              class="line-chart history-plot" />
+
+        <div id="content-core">
+          <form action=""
+                class="enableAutoFocus"
+                name="users_search"
+                method="post"
+                tal:attributes="action string:$portal_url/$template_id"
+                tal:define="findAll python:'form.button.FindAll' in request.keys();
+                            portal_users view/searchResults;
+                            batch python:Batch(portal_users, b_size, int(b_start), orphan=1);
+                            batchformkeys python:['searchstring','_authenticator'];
+                            many_users view/many_users">
+            <input type="hidden" name="form.submitted" value="1" />
+
+            <table class="listing" summary="User Listing">
+              <tbody>
+                <tr class="odd">
+                  <th colspan="6" tal:attributes="colspan python:len(portal_roles)+4">
+                    <span tal:omit-tag="" i18n:translate="label_user_search">User Search</span>:
+                    <input class="quickSearch"
+                           type="text"
+                           name="searchstring"
+                           value=""
+                           tal:attributes="value view/searchString;"
+                           />
+
+                    <input type="submit"
+                           class="searchButton"
+                           name="form.button.Search"
+                           value="Search"
+                           i18n:attributes="value label_search;"
+                           />
+
+                    <input type="submit"
+                           class="searchButton"
+                           name="form.button.FindAll"
+                           value="Show all"
+                           i18n:attributes="value label_showall;"
+                           tal:condition="not:many_users"
+                           />
+                  </th>
+                </tr>
+                <tal:block repeat="user batch">
+                  <tr tal:define="oddrow repeat/user/odd;
+                                  userid user/userid;
+                                  userquery python:view.makeQuery(userid=userid);"
+                      tal:attributes="class python:oddrow and 'odd' or 'even'">
+
+                    <td>
+                      <a href="@@user-information"
+                         tal:attributes="href string:$portal_url/@@user-information?${userquery};
+                                         title userid">
+                        <tal:block replace="structure context/portal_url/user.png"/>&nbsp;<span tal:replace="user/fullname">Full Name</span>
+                      </a>
+                      <input type="hidden" name="users.id:records" tal:attributes="value userid" />
+                      <input class="context"
+                             type="submit"
+                             name="form.button.AssignUser"
+                             value="users.id:records"
+                             i18n:attributes="value label_apply_changes;"
+                       />
+
+                    </td>
+                  </tr>
+                </tal:block>
+                <tr tal:condition="not:batch">
+                  <td tal:condition="view/searchString"
+                      i18n:translate="text_nomatches"
+                      style="text-align:center;">No matches</td>
+                  <tal:block tal:condition="not:view/searchString">
+                    <td tal:condition="many_users"
+                        class="discreet"
+                        i18n:translate="text_no_user_searchstring"
+                        style="text-align:center; font-size: 100%;">
+                        Enter a username to search for
+                    </td>
+                    <td tal:condition="not:many_users"
+                        class="discreet"
+                        i18n:translate="text_no_user_searchstring_largesite"
+                        style="text-align:center; font-size: 100%;">
+                        Enter a username to search for, or click 'Show All'
+                    </td>
+                  </tal:block>
+                </tr>
+              </tbody>
+            </table>
+
+            <div metal:use-macro="context/batch_macros/macros/navigation" />
+
+            <div class="showAllSearchResults"
+                 tal:condition="python:batch.next or batch.previous"
+                 tal:define="mq python:modules['ZTUtils'].make_query;
+                             keys batchformkeys|nothing;
+                             linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
+                             url batch_base_url | string:${context/absolute_url}/${template_id}">
+              <a tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
+                 i18n:translate="description_pas_show_all_search_results">
+                  Show all search results
+              </a>
+            </div>
+
+            <input tal:replace="structure context/@@authenticator/authenticator" />
+
+          </form>
+        </div>
+      </div>
     </div>
+  </metal:main>
 
-  </body>
+</body>
 </html>

--- a/ftw/linkchecker/browser/dashboard.pt
+++ b/ftw/linkchecker/browser/dashboard.pt
@@ -33,111 +33,115 @@
 
         <div id="content-core">
 
+
           <div tal:repeat="link_item python:enumerate(view.get_links())">
-          <form action=""
-                class="enableAutoFocus"
-                name="users_search"
-                method="post"
-                tal:attributes="action string:$portal_url/$template_id"
-                tal:define="findAll python:'form.button.FindAll' in request.keys();
-                            portal_users view/searchResults;
-                            batch python:Batch(portal_users, b_size, int(b_start), orphan=1);
-                            batchformkeys python:['searchstring','_authenticator'];
-                            many_users view/many_users">
-            <input type="hidden" name="form.submitted" value="1" />
+            <a class="linkchecker-toggle">Toggle Entry</a>
+            <div class="hide-show" style="display: none;">
+              <form action=""
+                    class="enableAutoFocus"
+                    name="users_search"
+                    method="post"
+                    tal:attributes="action string:$portal_url/$template_id"
+                    tal:define="findAll python:'form.button.FindAll' in request.keys();
+                                portal_users view/searchResults;
+                                batch python:Batch(portal_users, b_size, int(b_start), orphan=1);
+                                batchformkeys python:['searchstring','_authenticator'];
+                                many_users view/many_users">
+                <input type="hidden" name="form.submitted" value="1" />
 
-            <table class="listing" summary="User Listing">
-              <tbody>
-                <tr class="odd">
-                  <th colspan="6" tal:attributes="colspan python:len(portal_roles)+4">
-                    <span tal:omit-tag="" i18n:translate="label_user_search">User Search</span>:
-                    <input class="quickSearch"
-                           type="text"
-                           name="searchstring"
-                           value=""
-                           tal:attributes="value view/searchString;"
+                <table class="listing" summary="User Listing">
+                  <tbody>
+                    <tr class="odd">
+                      <th colspan="6" tal:attributes="colspan python:len(portal_roles)+4">
+                        <span tal:omit-tag="" i18n:translate="label_user_search">User Search</span>:
+                        <input class="quickSearch"
+                               type="text"
+                               name="searchstring"
+                               value=""
+                               tal:attributes="value view/searchString;"
+                               />
+
+                        <input type="submit"
+                               class="searchButton"
+                               name="form.button.Search"
+                               value="Search"
+                               i18n:attributes="value label_search;"
+                               />
+
+                        <input type="submit"
+                               class="searchButton"
+                               name="form.button.FindAll"
+                               value="Show all"
+                               i18n:attributes="value label_showall;"
+                               tal:condition="not:many_users"
+                               />
+                      </th>
+                    </tr>
+                    <tal:block repeat="user batch">
+                      <tr tal:define="oddrow repeat/user/odd;
+                                      userid user/userid;
+                                      userquery python:view.makeQuery(userid=userid);"
+                          tal:attributes="class python:oddrow and 'odd' or 'even'">
+
+                        <td>
+                          <a href="@@user-information"
+                             tal:attributes="href string:$portal_url/@@user-information?${userquery};
+                                             title userid">
+                            <tal:block replace="structure context/portal_url/user.png"/>&nbsp;<span tal:replace="user/fullname">Full Name</span>
+                          </a>
+
+                          <tal:definition tal:define="link_number python:link_item[0];
+                                                      link_data python:link_item[1]">
+                          <input class="context"
+                                 type="submit"
+                                 tal:attributes="value string:Assign;
+                                                 name string:assign_${link_number}_${userid}"
                            />
+                          </tal:definition>
 
-                    <input type="submit"
-                           class="searchButton"
-                           name="form.button.Search"
-                           value="Search"
-                           i18n:attributes="value label_search;"
-                           />
+                        </td>
+                      </tr>
+                    </tal:block>
+                    <tr tal:condition="not:batch">
+                      <td tal:condition="view/searchString"
+                          i18n:translate="text_nomatches"
+                          style="text-align:center;">No matches</td>
+                      <tal:block tal:condition="not:view/searchString">
+                        <td tal:condition="many_users"
+                            class="discreet"
+                            i18n:translate="text_no_user_searchstring"
+                            style="text-align:center; font-size: 100%;">
+                            Enter a username to search for
+                        </td>
+                        <td tal:condition="not:many_users"
+                            class="discreet"
+                            i18n:translate="text_no_user_searchstring_largesite"
+                            style="text-align:center; font-size: 100%;">
+                            Enter a username to search for, or click 'Show All'
+                        </td>
+                      </tal:block>
+                    </tr>
+                  </tbody>
+                </table>
 
-                    <input type="submit"
-                           class="searchButton"
-                           name="form.button.FindAll"
-                           value="Show all"
-                           i18n:attributes="value label_showall;"
-                           tal:condition="not:many_users"
-                           />
-                  </th>
-                </tr>
-                <tal:block repeat="user batch">
-                  <tr tal:define="oddrow repeat/user/odd;
-                                  userid user/userid;
-                                  userquery python:view.makeQuery(userid=userid);"
-                      tal:attributes="class python:oddrow and 'odd' or 'even'">
+                <div metal:use-macro="context/batch_macros/macros/navigation" />
 
-                    <td>
-                      <a href="@@user-information"
-                         tal:attributes="href string:$portal_url/@@user-information?${userquery};
-                                         title userid">
-                        <tal:block replace="structure context/portal_url/user.png"/>&nbsp;<span tal:replace="user/fullname">Full Name</span>
-                      </a>
+                <div class="showAllSearchResults"
+                     tal:condition="python:batch.next or batch.previous"
+                     tal:define="mq python:modules['ZTUtils'].make_query;
+                                 keys batchformkeys|nothing;
+                                 linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
+                                 url batch_base_url | string:${context/absolute_url}/${template_id}">
+                  <a tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
+                     i18n:translate="description_pas_show_all_search_results">
+                      Show all search results
+                  </a>
+                </div>
 
-                      <tal:definition tal:define="link_number python:link_item[0];
-                                                  link_data python:link_item[1]">
-                      <input class="context"
-                             type="submit"
-                             tal:attributes="value string:Assign;
-                                             name string:assign_${link_number}_${userid}"
-                       />
-                      </tal:definition>
+                <input tal:replace="structure context/@@authenticator/authenticator" />
 
-                    </td>
-                  </tr>
-                </tal:block>
-                <tr tal:condition="not:batch">
-                  <td tal:condition="view/searchString"
-                      i18n:translate="text_nomatches"
-                      style="text-align:center;">No matches</td>
-                  <tal:block tal:condition="not:view/searchString">
-                    <td tal:condition="many_users"
-                        class="discreet"
-                        i18n:translate="text_no_user_searchstring"
-                        style="text-align:center; font-size: 100%;">
-                        Enter a username to search for
-                    </td>
-                    <td tal:condition="not:many_users"
-                        class="discreet"
-                        i18n:translate="text_no_user_searchstring_largesite"
-                        style="text-align:center; font-size: 100%;">
-                        Enter a username to search for, or click 'Show All'
-                    </td>
-                  </tal:block>
-                </tr>
-              </tbody>
-            </table>
-
-            <div metal:use-macro="context/batch_macros/macros/navigation" />
-
-            <div class="showAllSearchResults"
-                 tal:condition="python:batch.next or batch.previous"
-                 tal:define="mq python:modules['ZTUtils'].make_query;
-                             keys batchformkeys|nothing;
-                             linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
-                             url batch_base_url | string:${context/absolute_url}/${template_id}">
-              <a tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
-                 i18n:translate="description_pas_show_all_search_results">
-                  Show all search results
-              </a>
+              </form>
             </div>
-
-            <input tal:replace="structure context/@@authenticator/authenticator" />
-
-          </form>
           </div>
 
         </div>

--- a/ftw/linkchecker/browser/dashboard.pt
+++ b/ftw/linkchecker/browser/dashboard.pt
@@ -33,117 +33,159 @@
 
         <div id="content-core">
 
-
           <div tal:repeat="link_item python:enumerate(view.get_links())">
-            <a class="linkchecker-toggle">Toggle Entry</a>
-            <div class="hide-show" style="display: none;">
-              <form action=""
-                    class="enableAutoFocus"
-                    name="users_search"
-                    method="post"
-                    tal:attributes="action string:$portal_url/$template_id"
-                    tal:define="findAll python:'form.button.FindAll' in request.keys();
-                                portal_users view/searchResults;
-                                batch python:Batch(portal_users, b_size, int(b_start), orphan=1);
-                                batchformkeys python:['searchstring','_authenticator'];
-                                many_users view/many_users">
-                <input type="hidden" name="form.submitted" value="1" />
+            <tal:prepare_data tal:define="link_number python:link_item[0];
+                                          link_data python:link_item[1]">
+
+
+              <span tal:content="link_data/Destination" />
+              <a tal:attributes="href link_data/Origin"><button>Visit</button></a>
+              <form action="" method="post">
+                <input type="hidden" name="link_number"
+                       tal:attributes="value link_number" />
+                <input type="hidden" name="target_state"
+                       tal:attributes="value python:False if link_data.get('is_done') else True" />
+                <input type="submit" name="toggle_done" id="toggle_done"
+                       tal:attributes="value python:False if link_data.get('is_done') else True">
+              </form>
+              <button class="linkchecker-toggle">
+                Toggle
+              </button>
+              <div class="hide-show" style="display: none;">
+                <form action=""
+                      class="enableAutoFocus"
+                      name="users_search"
+                      method="post"
+                      tal:attributes="action string:$portal_url/$template_id"
+                      tal:define="findAll python:'form.button.FindAll' in request.keys();
+                                  portal_users view/searchResults;
+                                  batch python:Batch(portal_users, b_size, int(b_start), orphan=1);
+                                  batchformkeys python:['searchstring','_authenticator'];
+                                  many_users view/many_users">
+                  <input type="hidden" name="form.submitted" value="1" />
+
+                  <table class="listing" summary="User Listing">
+                    <tbody>
+                      <tr class="odd">
+                        <th colspan="6" tal:attributes="colspan python:len(portal_roles)+4">
+                          <span tal:omit-tag="" i18n:translate="label_user_search">User Search</span>:
+                          <input class="quickSearch"
+                                 type="text"
+                                 name="searchstring"
+                                 value=""
+                                 tal:attributes="value view/searchString;"
+                                 />
+
+                          <input type="submit"
+                                 class="searchButton"
+                                 name="form.button.Search"
+                                 value="Search"
+                                 i18n:attributes="value label_search;"
+                                 />
+
+                          <input type="submit"
+                                 class="searchButton"
+                                 name="form.button.FindAll"
+                                 value="Show all"
+                                 i18n:attributes="value label_showall;"
+                                 tal:condition="not:many_users"
+                                 />
+                        </th>
+                      </tr>
+                      <tal:block repeat="user batch">
+                        <tr tal:define="oddrow repeat/user/odd;
+                                        userid user/userid;
+                                        userquery python:view.makeQuery(userid=userid);"
+                            tal:attributes="class python:oddrow and 'odd' or 'even'">
+
+                          <td>
+                            <a href="@@user-information"
+                               tal:attributes="href string:$portal_url/@@user-information?${userquery};
+                                               title userid">
+                              <tal:block replace="structure context/portal_url/user.png"/>&nbsp;<span tal:replace="user/fullname">Full Name</span>
+                            </a>
+
+                            <input class="context"
+                                   type="submit"
+                                   tal:attributes="value string:Assign;
+                                                   name string:assign_${link_number}_${userid}"
+                             />
+
+                          </td>
+                        </tr>
+                      </tal:block>
+                      <tr tal:condition="not:batch">
+                        <td tal:condition="view/searchString"
+                            i18n:translate="text_nomatches"
+                            style="text-align:center;">No matches</td>
+                        <tal:block tal:condition="not:view/searchString">
+                          <td tal:condition="many_users"
+                              class="discreet"
+                              i18n:translate="text_no_user_searchstring"
+                              style="text-align:center; font-size: 100%;">
+                              Enter a username to search for
+                          </td>
+                          <td tal:condition="not:many_users"
+                              class="discreet"
+                              i18n:translate="text_no_user_searchstring_largesite"
+                              style="text-align:center; font-size: 100%;">
+                              Enter a username to search for, or click 'Show All'
+                          </td>
+                        </tal:block>
+                      </tr>
+                    </tbody>
+                  </table>
+
+                  <div metal:use-macro="context/batch_macros/macros/navigation" />
+
+                  <div class="showAllSearchResults"
+                       tal:condition="python:batch.next or batch.previous"
+                       tal:define="mq python:modules['ZTUtils'].make_query;
+                                   keys batchformkeys|nothing;
+                                   linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
+                                   url batch_base_url | string:${context/absolute_url}/${template_id}">
+                    <a tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
+                       i18n:translate="description_pas_show_all_search_results">
+                        Show all search results
+                    </a>
+                  </div>
+
+                  <input tal:replace="structure context/@@authenticator/authenticator" />
+
+                </form>
 
                 <table class="listing" summary="User Listing">
                   <tbody>
                     <tr class="odd">
-                      <th colspan="6" tal:attributes="colspan python:len(portal_roles)+4">
-                        <span tal:omit-tag="" i18n:translate="label_user_search">User Search</span>:
-                        <input class="quickSearch"
-                               type="text"
-                               name="searchstring"
-                               value=""
-                               tal:attributes="value view/searchString;"
-                               />
-
-                        <input type="submit"
-                               class="searchButton"
-                               name="form.button.Search"
-                               value="Search"
-                               i18n:attributes="value label_search;"
-                               />
-
-                        <input type="submit"
-                               class="searchButton"
-                               name="form.button.FindAll"
-                               value="Show all"
-                               i18n:attributes="value label_showall;"
-                               tal:condition="not:many_users"
-                               />
-                      </th>
+                      <td>Source</td>
+                      <td tal:content="python:link_data.get('Origin')" />
                     </tr>
-                    <tal:block repeat="user batch">
-                      <tr tal:define="oddrow repeat/user/odd;
-                                      userid user/userid;
-                                      userquery python:view.makeQuery(userid=userid);"
-                          tal:attributes="class python:oddrow and 'odd' or 'even'">
-
-                        <td>
-                          <a href="@@user-information"
-                             tal:attributes="href string:$portal_url/@@user-information?${userquery};
-                                             title userid">
-                            <tal:block replace="structure context/portal_url/user.png"/>&nbsp;<span tal:replace="user/fullname">Full Name</span>
-                          </a>
-
-                          <tal:definition tal:define="link_number python:link_item[0];
-                                                      link_data python:link_item[1]">
-                          <input class="context"
-                                 type="submit"
-                                 tal:attributes="value string:Assign;
-                                                 name string:assign_${link_number}_${userid}"
-                           />
-                          </tal:definition>
-
-                        </td>
-                      </tr>
-                    </tal:block>
-                    <tr tal:condition="not:batch">
-                      <td tal:condition="view/searchString"
-                          i18n:translate="text_nomatches"
-                          style="text-align:center;">No matches</td>
-                      <tal:block tal:condition="not:view/searchString">
-                        <td tal:condition="many_users"
-                            class="discreet"
-                            i18n:translate="text_no_user_searchstring"
-                            style="text-align:center; font-size: 100%;">
-                            Enter a username to search for
-                        </td>
-                        <td tal:condition="not:many_users"
-                            class="discreet"
-                            i18n:translate="text_no_user_searchstring_largesite"
-                            style="text-align:center; font-size: 100%;">
-                            Enter a username to search for, or click 'Show All'
-                        </td>
-                      </tal:block>
+                    <tr class="even">
+                      <td>Editing State</td>
+                      <td tal:content="python:link_data.get('is_done')" />
+                    </tr>
+                    <tr class="odd">
+                      <td>HTTP Status Code</td>
+                      <td tal:content="python:link_data.get('Status Code')" />
+                    </tr>
+                    <tr class="even">
+                      <td>Workflow State</td>
+                      <td tal:content="python:link_data.get('Review State')" />
+                    </tr>
+                    <tr class="odd">
+                      <td>Internal/External</td>
+                      <td tal:content="python:link_data.get('Internal/External')" />
+                    </tr>
+                    <tr class="even">
+                      <td>Responsible</td>
+                      <td tal:content="python:link_data.get('responsible')" />
                     </tr>
                   </tbody>
                 </table>
 
-                <div metal:use-macro="context/batch_macros/macros/navigation" />
-
-                <div class="showAllSearchResults"
-                     tal:condition="python:batch.next or batch.previous"
-                     tal:define="mq python:modules['ZTUtils'].make_query;
-                                 keys batchformkeys|nothing;
-                                 linkparams python:keys and dict([(key, request.form[key]) for key in keys if key in request]) or request.form;
-                                 url batch_base_url | string:${context/absolute_url}/${template_id}">
-                  <a tal:attributes="href python: '%s?%s' % (url, mq( linkparams, {'showAll':'y'} ))"
-                     i18n:translate="description_pas_show_all_search_results">
-                      Show all search results
-                  </a>
-                </div>
-
-                <input tal:replace="structure context/@@authenticator/authenticator" />
-
-              </form>
-            </div>
+              </div>
+            </tal:prepare_data>
           </div>
-
         </div>
       </div>
     </div>

--- a/ftw/linkchecker/browser/dashboard.py
+++ b/ftw/linkchecker/browser/dashboard.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from numpy import nan
 from plone import api
+from plone.app.controlpanel.usergroups import UsersOverviewControlPanel
 from zope.annotation.interfaces import IAnnotations
 from zope.publisher.browser import BrowserView
 import base64
@@ -13,7 +14,31 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt  # noqa
 
 
-class Dashboard(BrowserView):
+class Dashboard(UsersOverviewControlPanel):
+
+    def __call__(self):
+
+        form = self.request.form
+        submitted = form.get('form.submitted', False)
+        search = form.get('form.button.Search', None) is not None
+        findAll = form.get('form.button.FindAll', None) is not None
+        self.searchString = not findAll and form.get('searchstring', '') or ''
+        self.searchResults = []
+        self.newSearch = False
+
+        if search or findAll:
+            self.newSearch = True
+
+        if submitted:
+            if form.get('form.button.AssignUser', None) is not None:
+                users = form.get('users', [])
+                # TODO: Assign User to link
+
+        # Only search for all ('') if the many_users flag is not set.
+        if not(self.many_users) or bool(self.searchString):
+            self.searchResults = self.doSearch(self.searchString)
+
+        return self.index()
 
     def __init__(self, context, request):
         super(Dashboard, self).__init__(context, request)

--- a/ftw/linkchecker/browser/dashboard.py
+++ b/ftw/linkchecker/browser/dashboard.py
@@ -30,8 +30,10 @@ class Dashboard(UsersOverviewControlPanel):
             self.newSearch = True
 
         if submitted:
-            if form.get('form.button.AssignUser', None) is not None:
-                users = form.get('users', [])
+            assignment = [key for key in form.keys() if 'assign' in key]
+            if assignment:
+                link_number = assignment[0][-6:].split('_', 1)[0]
+                userid_number = assignment[0][-6:].split('_', 1)[1]
                 # TODO: Assign User to link
 
         # Only search for all ('') if the many_users flag is not set.
@@ -45,6 +47,10 @@ class Dashboard(UsersOverviewControlPanel):
         self.dashboard_model = DashboardModel(self.context, self.request)
         self.graph_generator = GraphGenerator(
             self.dashboard_model.data, self.dashboard_model.history)
+
+    def get_links(self):
+        # TODO: provide links instead of dummy list
+        return [1, 2, 3, 4, 5, 6]
 
 
 class DashboardModel(object):

--- a/ftw/linkchecker/browser/dashboard.py
+++ b/ftw/linkchecker/browser/dashboard.py
@@ -1,12 +1,11 @@
 from datetime import datetime
-from numpy import nan
 from plone import api
 from plone.app.controlpanel.usergroups import UsersOverviewControlPanel
 from zope.annotation.interfaces import IAnnotations
-from zope.publisher.browser import BrowserView
 import base64
 import io
 import matplotlib
+import numpy as np
 import pandas as pd
 import time
 
@@ -29,6 +28,11 @@ class Dashboard(UsersOverviewControlPanel):
         if search or findAll:
             self.newSearch = True
 
+        if form.get('toggle_done'):
+            target_state = form.get('target_state')
+            link_number = form.get('link_number')
+            # TODO: Toggle link to state target_state
+
         if submitted:
             assignment = [key for key in form.keys() if 'assign' in key]
             if assignment:
@@ -49,8 +53,12 @@ class Dashboard(UsersOverviewControlPanel):
             self.dashboard_model.data, self.dashboard_model.history)
 
     def get_links(self):
-        # TODO: provide links instead of dummy list
-        return [1, 2, 3, 4, 5, 6]
+        link_data = self.dashboard_model.data.to_dict('records')
+        for link in link_data:
+            for key in link:
+                if key == 'Status Code' and not np.isnan(link[key]):
+                    link[key] = int(link[key])
+        return link_data
 
 
 class DashboardModel(object):
@@ -76,7 +84,7 @@ class DashboardModel(object):
                 # add data the first time
                 df_new = self._latest_report_df
                 df_new['is_done'] = False
-                df_new['responsible'] = nan
+                df_new['responsible'] = np.nan
                 self._set_annotation(
                     {'timestamp': self._timestamp_new,
                      'report_data': df_new.to_dict('records')})

--- a/ftw/linkchecker/browser/resources/general.js
+++ b/ftw/linkchecker/browser/resources/general.js
@@ -1,0 +1,6 @@
+$(function() {
+    $('.linkchecker-toggle').click(function() {
+        $(this).next('.hide-show').toggle();
+        $('.hide-show').not($(this).next('.hide-show')).hide();
+    });
+});

--- a/ftw/linkchecker/profiles/default/jsregistry.xml
+++ b/ftw/linkchecker/profiles/default/jsregistry.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts">
+
+    <javascript
+        id="++resource++ftw.linkchecker-resources/general.js"
+        compression="safe"
+        authenticated="False"
+        enabled="True"
+        />
+
+</object>

--- a/ftw/linkchecker/profiles/uninstall/jsregistry.xml
+++ b/ftw/linkchecker/profiles/uninstall/jsregistry.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts">
+
+    <javascript
+        id="++resource++ftw.linkchecker-resources/general.js"
+        remove="True" />
+
+</object>

--- a/ftw/linkchecker/tests/test_dashboard_view.py
+++ b/ftw/linkchecker/tests/test_dashboard_view.py
@@ -16,12 +16,7 @@ class TestDashboardFunctional(FunctionalTestCase):
         browser.visit(self.portal, view='linkchecker-dashboard')
 
         title = browser.css('.documentFirstHeading').first.text
-        content = browser.css('#content-core').first.text
 
         self.assertEqual(
             'Linkchecker Dashboard', title,
             'It is expected that the dashboards title is Linkchecker Dashboard.')
-
-        self.assertIn(
-            'Lorem ipsum', content,
-            'It is expected that Lorem ipsum is in the content.')

--- a/setup.py
+++ b/setup.py
@@ -8,14 +8,14 @@ version = '1.3.3.dev0'
 
 tests_require = [
     'ftw.builder',
+    'ftw.simplelayout [contenttypes]',
     'ftw.testbrowser',
     'ftw.testing',
+    'parameterized',
     'plone.app.testing',
     'plone.testing',
     'requests',
     'xlsxwriter',
-    'ftw.simplelayout [contenttypes]',
-    'parameterized',
 ]
 
 extras_require = {
@@ -24,7 +24,6 @@ extras_require = {
 
 install_requires = [
     'Plone',
-    'setuptools',
     'ftw.upgrade',
     'xlsxwriter',
     'pandas < 0.23a',


### PR DESCRIPTION
To get the whole functionality to search for users it was easiest to
inherit from plone.app.controlpanel.usergroups.UsersOverviewControlPanel.

To slightly change the aim of this View, I overwrote the call method
removing deleting and password reset functionality.

Also this commit uses broad parts of the views template
(usergroups_usersoverview.pt). Also in the template the actions for
removing, changing and password resetting are removed.

The View is not yet styled but contains all the data and buttons/forms except of the filtering functionality.

The top showing Plots:

![image](https://user-images.githubusercontent.com/29920936/80759045-f4d02d00-8b36-11ea-9764-e3cd64e76e78.png)

The second part showing links:

![image](https://user-images.githubusercontent.com/29920936/80759102-0c0f1a80-8b37-11ea-8da8-66ad29803ce4.png)
