### PR TITLE
Implement batching.

### DIFF
--- a/ftw/linkchecker/browser/dashboard.pt
+++ b/ftw/linkchecker/browser/dashboard.pt
@@ -14,7 +14,8 @@
                   b_start python:0 if showAll or view.newSearch else request.get('b_start',0);
                   b_size python:showAll and len(view.searchResults) or 20;
                   portal_roles view/portal_roles;
-                  portal_url context/portal_url;">
+                  portal_url context/portal_url;
+                  batch view/batch">
 
     <div class="documentEditable">
       <div id="content">
@@ -45,7 +46,7 @@
 
         <div id="content-core">
 
-          <div tal:repeat="link_item view/get_links"
+          <div tal:repeat="link_item batch"
                class="link-container">
 
             <span class="link-destination" tal:content="link_item/Destination" />
@@ -189,6 +190,7 @@
               </table>
             </div>
           </div>
+          <div metal:use-macro="context/batch_macros/macros/navigation" />
         </div>
       </div>
     </div>

--- a/ftw/linkchecker/browser/dashboard.py
+++ b/ftw/linkchecker/browser/dashboard.py
@@ -1,3 +1,4 @@
+from Products.CMFPlone.PloneBatch import Batch
 from datetime import datetime
 from plone import api
 from plone.app.controlpanel.usergroups import UsersOverviewControlPanel
@@ -57,10 +58,16 @@ class Dashboard(UsersOverviewControlPanel):
 
     def __init__(self, context, request, apply_filter=None):
         super(Dashboard, self).__init__(context, request)
+        self.batch_size = 10
         self.dashboard_model = DashboardModel(
             self.context, self.request, apply_filter=apply_filter)
         self.graph_generator = GraphGenerator(
             self.dashboard_model.data, self.dashboard_model.history)
+
+    @property
+    def batch(self):
+        b_start = self.request.form.get('b_start', 0)
+        return Batch(self.get_links(), self.batch_size, b_start)
 
     def get_links(self):
         link_data = self.dashboard_model.data.to_dict('records')


### PR DESCRIPTION
Some installation have many broken links. Therefor it's nice to have batching in use so that the page is not getting too long.

![image](https://user-images.githubusercontent.com/29920936/80832227-8483e300-8bec-11ea-9687-4304162dcede.png)
