### PR TITLE
Do fine tuning

### DIFF
--- a/ftw/linkchecker/browser/dashboard.pt
+++ b/ftw/linkchecker/browser/dashboard.pt
@@ -63,7 +63,7 @@
                      tal:attributes="checked python:'checked' if link_item.get('is_done') else ''"
                      onChange="submit();">
             </form>
-            <a class="linkchecker-toggle">
+            <a tal:attributes="class python:'linkchecker-toggle {}'.format(link_item.get('id'))">
               <span class="icon-arrow-down"></span>
             </a>
             <div class="hide-show detail-container" style="display: none;">

--- a/ftw/linkchecker/browser/dashboard.py
+++ b/ftw/linkchecker/browser/dashboard.py
@@ -273,7 +273,7 @@ class GraphGenerator(object):
             return
         status = self.df['Status Code'].fillna(0).astype(int).replace(0, 'NaN')
         quantity_per_status = status.value_counts(dropna=False)
-        fig = plt.figure()
+        fig = plt.figure(figsize=(6, 6))
         fig = quantity_per_status.plot.pie(
             label='', title='By Status Codes').figure
 
@@ -285,7 +285,7 @@ class GraphGenerator(object):
             return
         creator = self.df['Creator']
         quantity_per_creator = creator.value_counts(dropna=False)
-        fig = plt.figure()
+        fig = plt.figure(figsize=(6, 6))
         fig = quantity_per_creator.plot.pie(
             label='', title='By Creator').figure
 
@@ -297,7 +297,15 @@ class GraphGenerator(object):
             return
         state = self.df['Review State']
         quantity_per_state = state.value_counts(dropna=False)
-        fig = plt.figure()
+
+        # This assumes that workflows follow the pattern
+        # <wf-name>--STATUS--<wf-state-name>
+        index_replacement = {}
+        new_labels = [{wf: wf.split('--')[-1]} for wf in quantity_per_state.index]
+        [quantity_per_state.rename(index=new_label, inplace=True)
+         for new_label in new_labels]
+
+        fig = plt.figure(figsize=(6, 6))
         fig = quantity_per_state.plot.pie(
             label='', title='By Review State').figure
 
@@ -308,8 +316,9 @@ class GraphGenerator(object):
         if not len(self.df):
             return
         fig = plt.figure()
-        fig = self.history.plot.line(
-            label='', title="History by Status Code").figure
+        fig = self.history.plot(
+            label='', title="History by Status Code", marker='D',
+            figsize=(20, 6)).figure
 
         img_tag = self._generate_img_tag(fig)
         return img_tag

--- a/ftw/linkchecker/browser/dashboard.py
+++ b/ftw/linkchecker/browser/dashboard.py
@@ -179,11 +179,20 @@ class DashboardModel(object):
             return
 
     def _collect_history(self):
-        # TODO: implement collect number of values by self._reports
-        return pd.DataFrame(
-            {'301': [20, 18, 489, 675, 1776],
-             '404': [4, 25, 281, 600, 1900]},
-            index=[1990, 1997, 2003, 2009, 2014])
+        history_df = pd.DataFrame()
+        if not self._reports:
+            return history_df
+
+        for report_date, report in self._reports:
+            status_df = pd.read_excel(
+                io.BytesIO(report.get_data()))[['Status Code']]
+            cleaned_status_df = status_df[
+                'Status Code'].fillna(0).astype(int).replace(0, 'NaN')
+            quantity_per_status = cleaned_status_df.value_counts(
+                    ).to_frame().T.rename({'Status Code': report_date})
+            history_df = history_df.append(quantity_per_status)
+
+        return history_df
 
     def _update_data(self):
         # use only key cols and unique cols

--- a/ftw/linkchecker/browser/resources/general.css
+++ b/ftw/linkchecker/browser/resources/general.css
@@ -4,7 +4,6 @@
 
 .line-chart img {
   width: 100%;
-  height: max-content;
 }
 
 .link-container {

--- a/ftw/linkchecker/browser/resources/general.js
+++ b/ftw/linkchecker/browser/resources/general.js
@@ -1,8 +1,51 @@
 $(function() {
-    $('.linkchecker-toggle').click(function() {
-        $(this).next('.hide-show').toggle();
-        $('.hide-show').not($(this).next('.hide-show')).hide();
+  $('.linkchecker-toggle').click(function() {
+    $(this).next('.hide-show').toggle();
+    $('.hide-show').not($(this).next('.hide-show')).hide();
 
-        $('span', this).toggleClass('icon-arrow-up icon-arrow-down');
-    });
+    $('span', this).toggleClass('icon-arrow-up icon-arrow-down');
+
+    classes = $(this).attr('class')
+    createCookie('active-link', classes, 1)
+  });
+
+  openActiveLink();
 });
+
+function openActiveLink() {
+  var activeCookie = readCookie('active-link');
+  var activeLinkClasses = '.'.concat(activeCookie.split(' ').join('.'));
+
+  var activeElement = $(activeLinkClasses);
+  if ( activeElement.length ) {
+    activeElement.next('.hide-show').toggle()
+
+    // Source: https://stackoverflow.com/a/6677069/10750109
+    $([document.documentElement, document.body]).animate({
+      scrollTop: activeElement.offset().top
+    }, 0);
+  }
+}
+
+// Source https://stackoverflow.com/a/1599291/10750109
+function createCookie(name, value, days) {
+  if (days) {
+    var date = new Date();
+    date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+    var expires = "; expires=" + date.toGMTString();
+  }
+  else var expires = "";
+
+  document.cookie = name + "=" + value + expires + "; path=/";
+}
+
+function readCookie(name) {
+  var nameEQ = name + "=";
+  var ca = document.cookie.split(';');
+  for (var i = 0; i < ca.length; i++) {
+    var c = ca[i];
+    while (c.charAt(0) == ' ') c = c.substring(1, c.length);
+    if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
+  }
+  return null;
+}


### PR DESCRIPTION
This commit solves three issues.

The first is that there was only dummy data for the line plot until now. Now the pasts report data is used instead.

The second improves the formatting of plots. This is quite difficult since the size of the plots is measured incl. the title and labels. Depending on what labels there are the plot shrinks or grows in relation to the other pie plots. By increasing the size of the plot relative to the title and labels it gets easier to size them appropriately.

The third commit handles reopening the previous link after a page reload. This handles a strange behavior that all the links were closed after reloading for a user search. Therefore you wouldn't find yourself on the link anymore after searching the user to be assigned.